### PR TITLE
Fix net_data_writer::ensure

### DIFF
--- a/include/lnl/net_data_writer.h
+++ b/include/lnl/net_data_writer.h
@@ -71,14 +71,15 @@ namespace lnl {
 
     private:
         void ensure(size_t size) {
-            if (m_data.size() > size) {
+            size_t neededSize = size + m_position;
+            if (m_data.size() > neededSize) {
                 return;
             }
 
             do {
                 auto newSize = m_data.empty() ? 1 : m_data.size();
                 m_data.resize(newSize * GROWTH_FACTOR, 0);
-            } while (m_data.size() <= size);
+            } while (m_data.size() <= neededSize);
         }
     };
 }


### PR DESCRIPTION
net_data_writer::ensure only checked size of current write operation, not preparing for multiple writes